### PR TITLE
Fix display of 'Quick Look' section on mobile

### DIFF
--- a/assets/styles/components/organisms/OtherFeature.scss
+++ b/assets/styles/components/organisms/OtherFeature.scss
@@ -3,6 +3,7 @@
 
 .trails-other-feature {
   text-align: center;
+  width: 50%;
 
   &:hover {
     background-color: rgba($blue, 0.10)


### PR DESCRIPTION
Below, the first breakpoint, .trails-other-feature does not have a width. Because of this, the section looks broken on mobile. This seems to fix it on my end!  


[Here's](https://imgur.com/a/ZLKiM) how it looks on my machine.  


Hope this is helpful!